### PR TITLE
Pyteomics.auxilliary.cvquery

### DIFF
--- a/parser/MzIdParser.py
+++ b/parser/MzIdParser.py
@@ -392,7 +392,6 @@ class MzIdParser:
         db_sequences = []
         for db_id in self.mzid_reader._offset_index["DBSequence"].keys():
             db_sequence = self.mzid_reader.get_by_id(db_id, tag_id='DBSequence')
-            db_sequence_accessions = self.get_accessions(db_sequence)
             db_sequence_data = {
                 'id': db_id,
                 'accession': db_sequence["accession"],
@@ -408,8 +407,7 @@ class MzIdParser:
             # description
             try:
                 # get the key by checking for the protein description accession number
-                desc_key = list(db_sequence.keys())[db_sequence_accessions.index('MS:1001088')]
-                db_sequence_data['description'] = db_sequence[desc_key]
+                db_sequence_data['description'] = cvquery(db_sequence, 'MS:1001088')
             except ValueError:
                 db_sequence_data['description'] = None
 

--- a/parser/MzIdParser.py
+++ b/parser/MzIdParser.py
@@ -451,7 +451,6 @@ class MzIdParser:
             if 'Modification' in peptide.keys():
                 # parse modifications and crosslink info
                 for mod in peptide['Modification']:
-                    # accessions = self.get_accessions(mod)
                     # mod_location is 0-based for assigning modifications to correct amino acid
                     # mod['location'] is 1-based with 0 = n-terminal and len(pep)+1 = C-terminal
                     if mod['location'] == 0:
@@ -464,11 +463,7 @@ class MzIdParser:
                     # parse crosslinker info
                     # ToDo: crosslinker mod mass should go into Crosslinker Table together with
                     #   specificity info. Mapping to this table would work same as for modifications
-                    # if 'MS:1002509' in accessions or 'MS:1002510' in accessions:
-                        # use mod['location'] for link-site (1-based in database in line with
-                        # mzIdentML specifications)
-                        # link_site1 = mod['location']
-                        # cross-link donor
+                    # cross-link donor
                     crosslinker_pair_id = cvquery(mod, 'MS:1002509')
                     if crosslinker_pair_id is not None:
                         link_site1 = mod['location']

--- a/parser/MzIdParser.py
+++ b/parser/MzIdParser.py
@@ -783,17 +783,6 @@ class MzIdParser:
         """Write remaining information into Upload table."""
         self.writer.write_other_info(self.contains_crosslinks, self.warnings)
 
-    @staticmethod
-    def get_accessions(element):
-        """Get the cvParam accessions for the given element."""
-        accessions = []
-        for el in element.keys():
-            if hasattr(el, 'accession'):
-                accessions.append(el.accession)
-            else:
-                accessions.append('')
-        return accessions
-
     def get_cv_params(self, element, super_cls_accession=None):
         """
         Get the cvParams of an element.
@@ -802,10 +791,10 @@ class MzIdParser:
         :param super_cls_accession: (str) accession number of the superclass
         :return: filtered dictionary of cvParams
         """
-        accessions = self.get_accessions(element)
+        accessions = cvquery(element)
 
         if super_cls_accession is None:
-            filtered_idx = [i for i, a in enumerate(accessions) if a != '']
+            filtered_idx = list(accessions.keys())
         else:
             children = []
             if type(super_cls_accession) != list:

--- a/parser/MzIdParser.py
+++ b/parser/MzIdParser.py
@@ -1,4 +1,5 @@
 from pyteomics import mzid
+from pyteomics.auxiliary import cvquery
 import re
 import ntpath
 import json
@@ -255,17 +256,16 @@ class MzIdParser:
             mod_index = 0
             for mod in sid_protocol['ModificationParams']['SearchModification']:
                 accessions = self.get_accessions(mod)
-
                 # parse specificity rule accessions
                 specificity_rules = mod.get('SpecificityRules', [])
                 spec_rule_accessions = []
                 for spec_rule in specificity_rules:
-                    spec_rule_accession = self.get_accessions(spec_rule)
+                    spec_rule_accession = cvquery(spec_rule)
                     if len(spec_rule_accession) != 1:
                         raise MzIdParseException(
                             f'Error when parsing SpecificityRules from SearchModification:\n'
                             f'{json.dumps(mod)}')
-                    spec_rule_accessions.append(spec_rule_accession[0])
+                    spec_rule_accessions.append(list(spec_rule_accession.keys())[0])
 
                 # other modifications
                 # name

--- a/parser/MzIdParser.py
+++ b/parser/MzIdParser.py
@@ -451,7 +451,7 @@ class MzIdParser:
             if 'Modification' in peptide.keys():
                 # parse modifications and crosslink info
                 for mod in peptide['Modification']:
-                    accessions = self.get_accessions(mod)
+                    # accessions = self.get_accessions(mod)
                     # mod_location is 0-based for assigning modifications to correct amino acid
                     # mod['location'] is 1-based with 0 = n-terminal and len(pep)+1 = C-terminal
                     if mod['location'] == 0:
@@ -464,23 +464,25 @@ class MzIdParser:
                     # parse crosslinker info
                     # ToDo: crosslinker mod mass should go into Crosslinker Table together with
                     #   specificity info. Mapping to this table would work same as for modifications
-                    if 'MS:1002509' in accessions or 'MS:1002510' in accessions:
+                    # if 'MS:1002509' in accessions or 'MS:1002510' in accessions:
                         # use mod['location'] for link-site (1-based in database in line with
                         # mzIdentML specifications)
-                        link_site1 = mod['location']
+                        # link_site1 = mod['location']
                         # cross-link donor
-                        if 'MS:1002509' in accessions:
-                            key = list(mod.keys())[accessions.index('MS:1002509')]
-                            crosslinker_pair_id = mod[key]
-                            crosslinker_modmass = mod['monoisotopicMassDelta']
-                            crosslinker_accession = mod['name'].accession
-                        # cross-link acceptor/receiver
-                        if 'MS:1002510' in accessions:
-                            key = list(mod.keys())[accessions.index('MS:1002510')]
-                            crosslinker_pair_id = mod[key]
+                    crosslinker_pair_id = cvquery(mod, 'MS:1002509')
+                    if crosslinker_pair_id is not None:
+                        link_site1 = mod['location']
+                        crosslinker_modmass = mod['monoisotopicMassDelta']
+                        crosslinker_accession = mod['name'].accession
+                    # cross-link acceptor/
+                    if crosslinker_pair_id is None:
+                        crosslinker_pair_id = cvquery(mod, 'MS:1002510')
+                        if crosslinker_pair_id is not None:
+                            link_site1 = mod['location']
                             crosslinker_modmass = mod['monoisotopicMassDelta'] # should be zero but i guess include anyway? - CC
 
-                    else:  # save the modification info if it's not crosslink related
+                    if crosslinker_pair_id is None:
+                    # else:  # save the modification info if it's not crosslink related
                         # Commented out block that tried to match modifications on peptides to SearchModifications
                         # ToDo: Might want to revisit this in the future
                         # if mod['name'].accession == 'MS:1001460':  # unknown modification


### PR DESCRIPTION
replaces our get_accessions with Pyteomics.auxilliary.cvquery, still passing its tests